### PR TITLE
Support Terraform 0.11

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,38 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+#*       @global-owner1 @global-owner2
+*       @FitnessKeeper/devops
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+#*.js    @js-owner
+
+# You can also use email addresses if you prefer. They'll be
+# used to look up users just like we do for commit author
+# emails.
+#*.go docs@example.com
+
+# In this example, @doctocat owns any files in the build/logs
+# directory at the root of the repository and any of its
+# subdirectories.
+#/build/logs/ @doctocat
+
+# The `docs/*` pattern will match files like
+# `docs/getting-started.md` but not further nested files like
+# `docs/build-app/troubleshooting.md`.
+#docs/*  docs@example.com
+
+# In this example, @octocat owns any file in an apps directory
+# anywhere in your repository.
+#apps/ @octocat
+
+# In this example, @doctocat owns any file in the `/docs`
+# directory in the root of your repository.
+#/docs/ @doctocat

--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@ Terraform module for deploying and managing a generic [ECS](https://aws.amazon.c
 - `task_identifier` - Unique identifier for the task, used in naming resources.
 - `docker_image` - Docker image specification.
 
-#### Optional
-- `aws_profile` - AWS config profile to use (default `default`)
-
 Usage
 -----
 

--- a/alb.tf
+++ b/alb.tf
@@ -1,20 +1,17 @@
 # ALB
 
 data "aws_acm_certificate" "alb" {
-  provider = "aws.provided"
   count = "${var.alb_enable_https ? 1 : 0}"
   domain = "${var.acm_cert_domain}"
   statuses = ["ISSUED"]
 }
 
 data "aws_security_group" "ecs" {
-  provider = "aws.provided"
   id     = "${var.ecs_security_group_id}"
   vpc_id = "${data.aws_vpc.vpc.id}"
 }
 
 resource "aws_alb" "service" {
-  provider        = "aws.provided"
   count           = "${(var.alb_enable_https || var.alb_enable_http) ? 1 : 0}"
   name            = "${var.service_identifier}-${var.task_identifier}"
   internal        = "${var.alb_internal}"
@@ -28,7 +25,6 @@ resource "aws_alb" "service" {
 }
 
 resource "aws_alb_listener" "service_https" {
-  provider          = "aws.provided"
   count             = "${var.alb_enable_https ? 1 : 0}"
   load_balancer_arn = "${aws_alb.service.arn}"
   port              = "443"
@@ -43,7 +39,6 @@ resource "aws_alb_listener" "service_https" {
 }
 
 resource "aws_alb_listener" "service_http" {
-  provider          = "aws.provided"
   count             = "${var.alb_enable_http ? 1 : 0}"
   load_balancer_arn = "${aws_alb.service.arn}"
   port              = "80"
@@ -56,7 +51,6 @@ resource "aws_alb_listener" "service_http" {
 }
 
 resource "aws_alb_target_group" "service" {
-  provider = "aws.provided"
   name     = "${var.service_identifier}-${var.task_identifier}"
   port     = "${var.app_port}"
   protocol = "HTTP"
@@ -86,7 +80,6 @@ resource "aws_alb_target_group" "service" {
 }
 
 resource "aws_security_group" "alb" {
-  provider    = "aws.provided"
   count       = "${(var.alb_enable_https || var.alb_enable_http) ? 1 : 0}"
   name_prefix = "alb-${var.service_identifier}-${var.task_identifier}-"
   description = "Security group for ${var.service_identifier}-${var.task_identifier} ALB"
@@ -99,7 +92,6 @@ resource "aws_security_group" "alb" {
 }
 
 resource "aws_security_group_rule" "alb_ingress_https" {
-  provider          = "aws.provided"
   count             = "${var.alb_enable_https ? 1 : 0}"
   type              = "ingress"
   from_port         = 443
@@ -110,7 +102,6 @@ resource "aws_security_group_rule" "alb_ingress_https" {
 }
 
 resource "aws_security_group_rule" "alb_ingress_http" {
-  provider          = "aws.provided"
   count             = "${var.alb_enable_http ? 1 : 0}"
   type              = "ingress"
   from_port         = 80
@@ -121,7 +112,6 @@ resource "aws_security_group_rule" "alb_ingress_http" {
 }
 
 resource "aws_security_group_rule" "alb_egress" {
-  provider                 = "aws.provided"
   count                    = "${(var.alb_enable_https || var.alb_enable_http) ? 1 : 0}"
   type                     = "egress"
   from_port                = 0

--- a/ecs.tf
+++ b/ecs.tf
@@ -20,7 +20,6 @@ data "template_file" "container_definition" {
 }
 
 resource "aws_ecs_task_definition" "task" {
-  provider              = "aws.provided"
   family                = "${var.service_identifier}-${var.task_identifier}"
   container_definitions = "${data.template_file.container_definition.rendered}"
   network_mode          = "${var.network_mode}"
@@ -28,7 +27,6 @@ resource "aws_ecs_task_definition" "task" {
 }
 
 resource "aws_ecs_service" "service" {
-  provider        = "aws.provided"
   name            = "${var.service_identifier}-${var.task_identifier}-service"
   cluster         = "${var.ecs_cluster_arn}"
   task_definition = "${aws_ecs_task_definition.task.arn}"
@@ -55,7 +53,6 @@ resource "aws_ecs_service" "service" {
 }
 
 resource "aws_cloudwatch_log_group" "task" {
-  provider          = "aws.provided"
   name              = "${var.service_identifier}-${var.task_identifier}"
   retention_in_days = "${var.ecs_log_retention}"
 }

--- a/iam.tf
+++ b/iam.tf
@@ -66,13 +66,11 @@ resource "aws_iam_role" "service" {
 }
 
 resource "aws_iam_role_policy_attachment" "service" {
-  provider   = "aws.provided"
   role       = "${aws_iam_role.service.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
 }
 
 resource "aws_iam_role_policy_attachment" "task_extra" {
-  provider   = "aws.provided"
   count      = "${length(var.extra_task_policy_arns)}"
   role       = "${aws_iam_role.task.name}"
   policy_arn = "${var.extra_task_policy_arns[count.index]}"

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,9 @@
 # MAIN
 
-provider "aws" {
-  alias   = "provided"
-  profile = "${var.aws_profile}"
-  region  = "${var.region}"
-}
-
 data "aws_region" "region" {
   name = "${var.region}"
 }
 
 data "aws_vpc" "vpc" {
-  provider = "aws.provided"
   id = "${var.vpc_id}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "alb_dns_name" {
   description = "FQDN of ALB provisioned for service (if present)"
-  value       = "${(var.alb_enable_https || var.alb_enable_http) ? aws_alb.service.dns_name : "false"}"
+  value       = "${(var.alb_enable_https || var.alb_enable_http) ? element(concat(aws_alb.service.*.dns_name, list("")), 0) : "not created"}"
 }
 
 output "alb_zone_id" {
   description = "Route 53 zone ID of ALB provisioned for service (if present)"
-  value       = "${(var.alb_enable_https || var.alb_enable_http) ? aws_alb.service.zone_id : "false"}"
+  value       = "${(var.alb_enable_https || var.alb_enable_http) ? element(concat(aws_alb.service.*.zone_id, list("")), 0) : "not created"}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,3 @@
-variable "aws_profile" {
-  type        = "string"
-  description = "AWS profile to use when managing resources (default is 'default')"
-  default     = "default"
-}
-
 variable "region" {
   type        = "string"
   description = "AWS region in which ECS cluster is located (default is 'us-east-1')"


### PR DESCRIPTION
This adds support for Terraform 0.11:
- uses splat syntax for outputs that might not exist (this is a warning in 0.11 and will be an error in 0.12, see https://www.terraform.io/upgrade-guides/0-11.html#referencing-attributes-from-resources-with-count-0)