### PR TITLE
Adding iam role outputs to the module

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -1,8 +1,8 @@
 # ALB
 
 data "aws_acm_certificate" "alb" {
-  count = "${var.alb_enable_https ? 1 : 0}"
-  domain = "${var.acm_cert_domain}"
+  count    = "${var.alb_enable_https ? 1 : 0}"
+  domain   = "${var.acm_cert_domain}"
   statuses = ["ISSUED"]
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -54,9 +54,9 @@ resource "aws_iam_role" "task" {
 }
 
 resource "aws_iam_role_policy" "task" {
-  name_prefix   = "${var.service_identifier}-${var.task_identifier}-ecsTaskPolicy"
-  role   = "${aws_iam_role.task.id}"
-  policy = "${data.aws_iam_policy_document.task_policy.json}"
+  name_prefix = "${var.service_identifier}-${var.task_identifier}-ecsTaskPolicy"
+  role        = "${aws_iam_role.task.id}"
+  policy      = "${data.aws_iam_policy_document.task_policy.json}"
 }
 
 resource "aws_iam_role" "service" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,23 @@ output "alb_zone_id" {
   description = "Route 53 zone ID of ALB provisioned for service (if present)"
   value       = "${(var.alb_enable_https || var.alb_enable_http) ? element(concat(aws_alb.service.*.zone_id, list("")), 0) : "not created"}"
 }
+
+output "task_iam_role_arn" {
+  description = "ARN of the IAM Role for the ECS Task"
+  value       = "${aws_iam_role.task.arn}"
+}
+
+output "task_iam_role_name" {
+  description = "Name of the IAM Role for the ECS Task"
+  value       = "${aws_iam_role.task.name}"
+}
+
+output "service_iam_role_arn" {
+  description = "ARN of the IAM Role for the ECS Service"
+  value       = "${aws_iam_role.service.arn}"
+}
+
+output "service_iam_role_name" {
+  description = "Name of the IAM Role for the ECS Task"
+  value       = "${aws_iam_role.service.name}"
+}


### PR DESCRIPTION
This adds outputs for both the iam roles task and service, and ouputs
both the names, as well as the arn's for use by other code

Also ran terraform fmt