### PR TITLE
Adds health_check_grace_period_seconds to module

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Terraform module for deploying and managing a generic [ECS](https://aws.amazon.c
 - `app_port` - Numeric port on which application listens (unnecessary if neither alb_enable_https or alb_enable_http are true)
 - `ecs_deployment_maximum_percent` - Upper limit in percentage of tasks that can be running during a deployment (default 200)
 - `ecs_deployment_minimum_healthy_percent` - Lower limit in percentage of tasks that must remain healthy during a deployment (default 100)
+- `ecs_health_check_grace_period` - Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 1800. (default 500)
 - `ecs_placement_strategy_type` - Placement strategy to use when distributing tasks (default binpack)
 - `ecs_placement_strategy_field` - Container metadata field to use when distributing tasks (default memory)
 - `ecs_log_retention` - Number of days of ECS task logs to retain (default 3)

--- a/ecs.tf
+++ b/ecs.tf
@@ -31,7 +31,7 @@ resource "aws_ecs_task_definition" "task" {
   task_role_arn         = "${aws_iam_role.task.arn}"
 
   volume {
-    name = "data"
+    name      = "data"
     host_path = "${var.ecs_data_volume_path}"
   }
 }
@@ -44,6 +44,7 @@ resource "aws_ecs_service" "service" {
   iam_role                           = "${aws_iam_role.service.arn}"
   deployment_maximum_percent         = "${var.ecs_deployment_maximum_percent}"
   deployment_minimum_healthy_percent = "${var.ecs_deployment_minimum_healthy_percent}"
+  health_check_grace_period_seconds  = "${var.ecs_health_check_grace_period}"
 
   placement_strategy {
     type  = "${var.ecs_placement_strategy_type}"

--- a/files/container_definition.json
+++ b/files/container_definition.json
@@ -3,15 +3,22 @@
         "name": "${service_identifier}-${task_identifier}",
         "image": "${image}",
         "memory": ${memory},
+        "cpu": 0,
+        "essential": true,
         "memoryReservation": ${memory_reservation},
         "portMappings": [
           {
-            "containerPort": ${app_port}
+            "containerPort": ${app_port},
+            "hostPort": 0,
+            "protocol": "tcp"
           }
         ],
         ${command_override}
         "environment": ${environment},
         "mountPoints": ${mount_points},
+        "volumesFrom": [
+          
+        ],
         "logConfiguration": {
             "logDriver": "awslogs",
             "options": {

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,11 @@ variable "ecs_deployment_minimum_healthy_percent" {
   description = "Lower limit in percentage of tasks that must remain healthy during a deployment (default 100)"
 }
 
+variable "ecs_health_check_grace_period" {
+  default     = "500"
+  description = "Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 1800. (default 500)"
+}
+
 variable "docker_command" {
   description = "String to override CMD in Docker container (default \"\")"
   default     = ""


### PR DESCRIPTION
Also update formating to pass tests
Updated ECS Service to allow us to use the terraform aws provider
greater then 1.0.3